### PR TITLE
LPS-28982 Disable add record when staging

### DIFF
--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -929,6 +929,31 @@ public class StagingImpl implements Staging {
 		return false;
 	}
 
+	public boolean isStagedPortlet(long groupId, String portletId) {
+		Group group = null;
+
+		try {
+			groupId = PortalUtil.getParentGroupId(groupId);
+
+			group = GroupLocalServiceUtil.getGroup(groupId);
+		}
+		catch (Exception e) {
+			return false;
+		}
+
+		if (!group.isStagingGroup() || Validator.isNull(portletId)) {
+			return false;
+		}
+
+		group = group.getLiveGroup();
+
+		if (group.isStagedPortlet(portletId)) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public void publishLayout(
 			long userId, long plid, long liveGroupId, boolean includeChildren)
 		throws Exception {

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/util/DDLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/util/DDLImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.templateparser.Transformer;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -368,6 +369,13 @@ public class DDLImpl implements DDL {
 			serviceContext, "majorVersion");
 
 		DDLRecord record = DDLRecordLocalServiceUtil.fetchRecord(recordId);
+
+		long scopeGroupId = serviceContext.getScopeGroupId();
+		String portletId = serviceContext.getPortletId();
+
+		if (StagingUtil.isStagedPortlet(scopeGroupId, portletId)) {
+			return record;
+		}
 
 		DDLRecordSet recordSet = DDLRecordSetLocalServiceUtil.getDDLRecordSet(
 			recordSetId);

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -1330,6 +1330,7 @@ check-box=Check Box
 check-every=Check Every
 check-mail=Check Mail
 check-to-allow-users-to-add-records-to-the-list=Check to allow users to add records to the list.
+check-to-allow-users-to-add-records-to-the-list-once-this-application-is-published-to-live=Check to allow users to add records to the list once this application is published to live.
 check-to-apply-the-changes-to-existing-users=Check to apply the changes to existing users. Changes take effect the next time a user signs in.
 check-to-view-the-list-records-in-a-spreadsheet=Check to view the list records in a spreadsheet.
 check-your-email-or-configure-email-accounts=<a href="{0}">Check your email</a> or <a href="{1}">configure email accounts.</a>

--- a/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
@@ -150,6 +150,8 @@ public interface Staging {
 
 	public boolean isIncomplete(Layout layout, long layoutSetBranchId);
 
+	public boolean isStagedPortlet(long groupId, String portletId);
+
 	public void publishLayout(
 			long userId, long plid, long liveGroupId, boolean includeChildren)
 		throws Exception;

--- a/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
@@ -260,6 +260,10 @@ public class StagingUtil {
 		return getStaging().isIncomplete(layout, layoutSetBranchId);
 	}
 
+	public static boolean isStagedPortlet(long groupId, String portletId) {
+		return getStaging().isStagedPortlet(groupId, portletId);
+	}
+
 	public static void publishLayout(
 			long userId, long plid, long liveGroupId, boolean includeChildren)
 		throws Exception {

--- a/portal-web/docroot/html/portlet/dynamic_data_list_display/configuration.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_list_display/configuration.jsp
@@ -104,7 +104,18 @@ request.setAttribute("record_set_action.jsp-selRecordSet", selRecordSet);
 
 			</aui:select>
 
-			<aui:input helpMessage="check-to-allow-users-to-add-records-to-the-list" name="editable" onChange='<%= "document." + renderResponse.getNamespace() + "fm." + renderResponse.getNamespace() + "editable.value = this.checked;" %>' type="checkbox" value="<%= editable %>" />
+			<%
+			String editableHelpMessage = null;
+
+			if (stagedPortlet) {
+				editableHelpMessage = "check-to-allow-users-to-add-records-to-the-list-once-this-application-is-published-to-live";
+			}
+			else {
+				editableHelpMessage = "check-to-allow-users-to-add-records-to-the-list";
+			}
+			%>
+
+			<aui:input helpMessage="<%= editableHelpMessage %>" name="editable" onChange='<%= "document." + renderResponse.getNamespace() + "fm." + renderResponse.getNamespace() + "editable.value = this.checked;" %>' type="checkbox" value="<%= editable %>" />
 
 			<aui:input helpMessage="check-to-view-the-list-records-in-a-spreadsheet" label="spreadsheet-view" name="spreadsheet" onChange='<%= "document." + renderResponse.getNamespace() + "fm." + renderResponse.getNamespace() + "spreadsheet.value = this.checked;" %>' type="checkbox" value="<%= spreadsheet %>" />
 		</aui:fieldset>

--- a/portal-web/docroot/html/portlet/dynamic_data_list_display/init.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_list_display/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ include file="/html/portlet/init.jsp" %>
 
-<%@ page import="com.liferay.portlet.dynamicdatalists.NoSuchRecordSetException" %><%@
+<%@ page import="com.liferay.portal.kernel.staging.StagingUtil" %><%@
+page import="com.liferay.portlet.dynamicdatalists.NoSuchRecordSetException" %><%@
 page import="com.liferay.portlet.dynamicdatalists.model.DDLRecordSet" %><%@
 page import="com.liferay.portlet.dynamicdatalists.model.DDLRecordSetConstants" %><%@
 page import="com.liferay.portlet.dynamicdatalists.search.RecordSetDisplayTerms" %><%@
@@ -48,6 +49,8 @@ long detailDDMTemplateId = GetterUtil.getLong(preferences.getValue("detailDDMTem
 long listDDMTemplateId = GetterUtil.getLong(preferences.getValue("listDDMTemplateId", StringPool.BLANK));
 
 boolean editable = GetterUtil.getBoolean(preferences.getValue("editable", Boolean.TRUE.toString()));
+boolean stagedPortlet = StagingUtil.isStagedPortlet(themeDisplay.getScopeGroupId(), portletDisplay.getId());
+
 boolean spreadsheet = GetterUtil.getBoolean(preferences.getValue("spreadsheet", Boolean.FALSE.toString()));
 
 String ddmResource = portletConfig.getInitParameter("ddm-resource");

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/init.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/init.jsp
@@ -20,6 +20,7 @@
 page import="com.liferay.portal.kernel.search.Hits" %><%@
 page import="com.liferay.portal.kernel.search.SearchContext" %><%@
 page import="com.liferay.portal.kernel.search.SearchContextFactory" %><%@
+page import="com.liferay.portal.kernel.staging.StagingUtil" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowDefinition" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowDefinitionManagerUtil" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowEngineManagerUtil" %><%@
@@ -55,6 +56,8 @@ String ddmResource = portletConfig.getInitParameter("ddm-resource");
 
 Format dateFormatDate = FastDateFormatFactoryUtil.getDate(locale, timeZone);
 Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
+
+boolean stagedPortlet = StagingUtil.isStagedPortlet(themeDisplay.getScopeGroupId(), portletDisplay.getId());
 %>
 
 <%@ include file="/html/portlet/dynamic_data_lists/init-ext.jsp" %>

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_records.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_records.jsp
@@ -63,7 +63,7 @@ portletURL.setParameter("recordSetId", String.valueOf(recordSet.getRecordSetId()
 
 	boolean showAddRecordButton = false;
 
-	if (editable) {
+	if (editable && !stagedPortlet) {
 		showAddRecordButton = DDLRecordSetPermission.contains(permissionChecker, recordSet, ActionKeys.ADD_RECORD);
 	}
 	%>

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_spreadsheet_records.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_spreadsheet_records.jsp
@@ -29,6 +29,12 @@ if (!DDLRecordSetPermission.contains(permissionChecker, recordSet.getRecordSetId
 	editable = false;
 }
 
+boolean showAddRecordsButton = editable;
+
+if (stagedPortlet) {
+	showAddRecordsButton = false;
+}
+
 DDMStructure ddmStructure = recordSet.getDDMStructure();
 %>
 
@@ -39,7 +45,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 		</div>
 	</div>
 
-	<c:if test="<%= editable %>">
+	<c:if test="<%= showAddRecordsButton %>">
 		<div class="lfr-spreadsheet-add-rows-buttons">
 			<aui:button inlineField="<%= true %>" name="addRecords" value="add" />
 
@@ -169,7 +175,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 
 	spreadSheet.get('boundingBox').unselectable();
 
-	<c:if test="<%= editable %>">
+	<c:if test="<%= showAddRecordsButton %>">
 		var numberOfRecordsNode = A.one('#<portlet:namespace />numberOfRecords');
 
 		A.one('#<portlet:namespace />addRecords').on(

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_template_records.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_template_records.jsp
@@ -22,6 +22,12 @@ DDLRecordSet recordSet = null;
 if (Validator.isNotNull(recordSetId)) {
 	recordSet = DDLRecordSetLocalServiceUtil.getRecordSet(recordSetId);
 }
+
+boolean showAddRecordButton = false;
+
+if (editable && !stagedPortlet) {
+	showAddRecordButton = DDLRecordSetPermission.contains(permissionChecker, recordSet.getRecordSetId(), ActionKeys.ADD_RECORD);
+}
 %>
 
 <portlet:actionURL var="editRecordSetURL">
@@ -29,7 +35,7 @@ if (Validator.isNotNull(recordSetId)) {
 </portlet:actionURL>
 
 <aui:form action="<%= editRecordSetURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveRecordSet();" %>'>
-	<c:if test="<%= DDLRecordSetPermission.contains(permissionChecker, recordSet.getRecordSetId(), ActionKeys.ADD_RECORD) && editable %>">
+	<c:if test="<%= showAddRecordButton %>">
 		<aui:button onClick='<%= renderResponse.getNamespace() + "addRecord();" %>' value="add-record" />
 
 		<div class="separator"><!-- --></div>


### PR DESCRIPTION
Hey Jorge,

as you requested I moved the method from the DDLImpl to a more generic place, but I think since this one is really staging related I put that into stagingUtil/impl. I also renamed, but not to isStagedPortlet() because it should return true only when the portlet is staged however the groupId is the staging group's one not the live, so I used the isStagingPortlet() name instead. 

Please let me know your opinion!

I also spent some time on the method itself, and after I checked how the groupImpl.isStagedPortlet works I decided to use the livegroup because it contains the typesettings with the required information and not the stagingGroup and I also use the parentGroup instead of the original group parameter because we follow that pattern on the groupImpl and in this way the method is more generic.

Thanks,
Daniel
