### PR TITLE
LPS-32231 javascript: links need one more level of encoding

### DIFF
--- a/portal-web/docroot/html/portlet/update_manager/plugin_package_action.jsp
+++ b/portal-web/docroot/html/portlet/update_manager/plugin_package_action.jsp
@@ -45,7 +45,7 @@ if (availablePluginPackage != null) {
 		</portlet:actionURL>
 
 		<%
-		String taglibUpdateURL = "javascript:" + uploadProgressId + ".startProgress(); submitForm(document.hrefFm, '" + updateURL + "');";
+		String taglibUpdateURL = "javascript:" + uploadProgressId + ".startProgress(); submitForm(document.hrefFm, '" + HttpUtil.encodeURL(updateURL) + "');";
 		%>
 
 		<liferay-ui:icon
@@ -64,7 +64,7 @@ if (availablePluginPackage != null) {
 				</portlet:actionURL>
 
 				<%
-				String taglibIgnoreURL = "javascript:submitForm(document.hrefFm, '" + ignoreURL + "');";
+				String taglibIgnoreURL = "javascript:submitForm(document.hrefFm, '" + HttpUtil.encodeURL(ignoreURL) + "');";
 				%>
 
 				<liferay-ui:icon
@@ -82,7 +82,7 @@ if (availablePluginPackage != null) {
 				</portlet:actionURL>
 
 				<%
-				String taglibUnignoreURL = "javascript:submitForm(document.hrefFm, '" + unignoreURL + "');";
+				String taglibUnignoreURL = "javascript:submitForm(document.hrefFm, '" + HttpUtil.encodeURL(unignoreURL) + "');";
 				%>
 
 				<liferay-ui:icon
@@ -103,7 +103,7 @@ if (availablePluginPackage != null) {
 		</portlet:actionURL>
 
 		<%
-		String taglibUninstallURL = "javascript:submitForm(document.hrefFm, '" + uninstallURL + "');";
+		String taglibUninstallURL = "javascript:submitForm(document.hrefFm, '" + HttpUtil.encodeURL(uninstallURL) + "');";
 		%>
 
 		<liferay-ui:icon


### PR DESCRIPTION
(Not a support request, just fixing this for fun)

The browsers decode the URL which we give to the submitForm method and it causes the server to use the parameters of the redirect value.

The fix will use the HttpUtil.encodeURL(String) method as it seen in the dockbar/view.jsp.

This is only issue when as javascript: links (like this: javascript:submitForm(document.hrefFm, '" + HttpUtil.encodeURL(uninstallURL) + "')
