### PR TITLE
LPS-35376 Checkboxes for Metadata are ignored

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -281,24 +281,22 @@ public class PortletDataContextImpl implements PortletDataContext {
 		addLocks(clazz, String.valueOf(classPK));
 		addPermissions(clazz, classPK);
 
-		boolean portletMetadataAll = MapUtil.getBoolean(
-			getParameterMap(), PortletDataHandlerKeys.PORTLET_METADATA_ALL);
+		boolean portletDataAll = MapUtil.getBoolean(
+			getParameterMap(), PortletDataHandlerKeys.PORTLET_DATA_ALL);
 
-		if (portletMetadataAll ||
-			getBooleanParameter(namespace, "categories")) {
-
+		if (portletDataAll || getBooleanParameter(namespace, "categories")) {
 			addAssetCategories(clazz, classPK);
 		}
 
-		if (portletMetadataAll || getBooleanParameter(namespace, "comments")) {
+		if (portletDataAll || getBooleanParameter(namespace, "comments")) {
 			addComments(clazz, classPK);
 		}
 
-		if (portletMetadataAll || getBooleanParameter(namespace, "ratings")) {
+		if (portletDataAll || getBooleanParameter(namespace, "ratings")) {
 			addRatingsEntries(clazz, classPK);
 		}
 
-		if (portletMetadataAll || getBooleanParameter(namespace, "tags")) {
+		if (portletDataAll || getBooleanParameter(namespace, "tags")) {
 			addAssetTags(clazz, classPK);
 		}
 
@@ -1243,14 +1241,14 @@ public class PortletDataContextImpl implements PortletDataContext {
 		importLocks(clazz, String.valueOf(classPK), String.valueOf(newClassPK));
 		importPermissions(clazz, classPK, newClassPK);
 
-		boolean portletMetadataAll = MapUtil.getBoolean(
-			getParameterMap(), PortletDataHandlerKeys.PORTLET_METADATA_ALL);
+		boolean portletDataAll = MapUtil.getBoolean(
+			getParameterMap(), PortletDataHandlerKeys.PORTLET_DATA_ALL);
 
-		if (portletMetadataAll || getBooleanParameter(namespace, "comments")) {
+		if (portletDataAll || getBooleanParameter(namespace, "comments")) {
 			importComments(clazz, classPK, newClassPK, getScopeGroupId());
 		}
 
-		if (portletMetadataAll || getBooleanParameter(namespace, "ratings")) {
+		if (portletDataAll || getBooleanParameter(namespace, "ratings")) {
 			importRatingsEntries(clazz, classPK, newClassPK);
 		}
 	}
@@ -1725,11 +1723,11 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 		// Asset
 
-		boolean portletMetadataAll = MapUtil.getBoolean(
-			getParameterMap(), PortletDataHandlerKeys.PORTLET_METADATA_ALL);
+		boolean portletDataAll = MapUtil.getBoolean(
+			getParameterMap(), PortletDataHandlerKeys.PORTLET_DATA_ALL);
 
 		if (isResourceMain(classedModel)) {
-			if (portletMetadataAll ||
+			if (portletDataAll ||
 				getBooleanParameter(namespace, "categories")) {
 
 				long[] assetCategoryIds = getAssetCategoryIds(clazz, classPK);
@@ -1737,7 +1735,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 				serviceContext.setAssetCategoryIds(assetCategoryIds);
 			}
 
-			if (portletMetadataAll || getBooleanParameter(namespace, "tags")) {
+			if (portletDataAll || getBooleanParameter(namespace, "tags")) {
 				String[] assetTagNames = getAssetTagNames(clazz, classPK);
 
 				serviceContext.setAssetTagNames(assetTagNames);

--- a/portal-impl/test/integration/com/liferay/portlet/journal/lar/JournalExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/lar/JournalExportImportTest.java
@@ -166,9 +166,6 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 		parameterMap.put(
 			PortletDataHandlerKeys.PORTLET_DATA_CONTROL_DEFAULT,
 			new String[] {Boolean.FALSE.toString()});
-		parameterMap.put(
-			PortletDataHandlerKeys.PORTLET_METADATA_ALL,
-			new String[] {Boolean.TRUE.toString()});
 
 		addParameter(parameterMap, "categories", true);
 		addParameter(parameterMap, "comments", true);

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandlerKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandlerKeys.java
@@ -74,8 +74,6 @@ public class PortletDataHandlerKeys {
 	public static final String PORTLET_DATA_CONTROL_DEFAULT =
 		"PORTLET_DATA_CONTROL_DEFAULT";
 
-	public static final String PORTLET_METADATA_ALL = "PORTLET_METADATA_ALL";
-
 	public static final String PORTLET_SETUP = "PORTLET_SETUP";
 
 	public static final String PORTLET_SETUP_ALL = "PORTLET_SETUP_ALL";


### PR DESCRIPTION
Hey Jorge,

As we discussed, with the new design the "All Content" option means all data and all metadata. We haven't any "All Metadata" control now. Thus, to export the so-called metadata (categories, comments, ratings, tags) the PORTLET_DATA_ALL param will be considered instead of the PORTLET_METADATA_ALL param.

I also noticed that this param was being obtained from the param map by using the portlet namespace, what is not correct. Neither the PORTLET_DATA_ALL nor PORTLET_METADATA_ALL are namespaced since they are global.

Thanks!

@juliocamarero
@MateThurzo
