### PR TITLE
LPS-35826 Can't install plugin form version 9 to 10: version 9 is newer ...

### DIFF
--- a/portal-service/test/unit/com/liferay/portal/kernel/plugin/VersionTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/plugin/VersionTest.java
@@ -27,6 +27,13 @@ public class VersionTest extends TestCase {
 		assertLater("1.2.0", "1.1.1");
 	}
 
+	public void testBuildNumber() {
+		assertPrevious("1.1.1.0", "1.1.1.1");
+		assertPrevious("1.1.1.1", "1.1.1.1.1");
+		assertPrevious("1.1.1.2+", "1.1.1.10");
+		assertLater("1.1.1.2+", "1.1.1.2");
+	}
+
 	public void testMajorNumber() {
 		assertPrevious("1.1", "1.1.1");
 		assertLater("2", "1.1.1");


### PR DESCRIPTION
...than version 10.

Hi Jorge,

The fix logic as the fllowings:

Firstly, we will split version information by "." to array, then we compare array element value to judge the result.

As for buildnumber are 9(6.1.20.9) and 10(6.1.20.10), if the two previousBuildNumber and newBuildNumber are both digit, it will on the basis of int compare. The result is 10 > 9. In 
unit tests, the code "assertPrevious("1.1.1.0", "1.1.1.1");" test the function.

As for the buildnumber is 9 and 9.1, it will be on the basis of array length compare. The result is 2[9,1] length > 1[9]. In unit tests, the code "assertPrevious("1.1.1.1", "1.1.1.1.1");" test the function.

As for the buildnumber is 9 and 10+, we will extract Digits from the both of buildnumber to compare, 10 > 9, so the result is 10+ > 9. In unit tests, the code "assertPrevious("1.1.1.2+", "1.1.1.10");" test the function.

As for the buildnumber is 10a and 10+, we firstlt will extract Digits from the both of buildnumber to compare, when the extract Digits is equal(10=10), it will be based on the Unicode value of each character in the strings. In unit tests, the code "assertLater("1.1.1.2+", "1.1.1.2");" test the function.

Please help check it.

Thanks,
Hai
