### PR TITLE
LPS-40736 Normalize newly created staging URLs as well

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -296,7 +296,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		if (staging) {
 			name = name.concat(" (Staging)");
-			friendlyURL = friendlyURL.concat("-staging");
+			friendlyURL = getStagingFriendlyURL(friendlyURL);
 		}
 
 		if (parentGroupId == GroupConstants.DEFAULT_PARENT_GROUP_ID) {
@@ -4096,6 +4096,10 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		}
 
 		return CustomSQLUtil.keywords(name);
+	}
+
+	protected String getStagingFriendlyURL(String friendlyURL) {
+		return getFriendlyURL(friendlyURL.concat("-staging"));
 	}
 
 	protected void initImportLARFile() {


### PR DESCRIPTION
Hi Jorge,

this is a small fix for sites contains only non-Alphanumeric characters on their name. The problem is we generate group friendly URL "-", "-1", "-2"... for these groups and when we creates the staging group for these we append "-staging" at the end of the original group friendly URL. For the first one the result is: "/--stgaing", however FriendlyURLServlet calls the GLSI.fetchFriendlyURLGroup() which calls a FriendlyURLNormalizerUtil.normalize(friendlyURL) before pass the friendlyURL param which result "/-staging". After checking the GLSI.getFriendlyURL(many params) I found we call the  GLSI.getFriendlyURL(String friendlyURL) to force to normalize the produced string, so I implemented the same logic and re-factored the code to a new method.

cc'-ing: @matethurzo

thanks,
Daniel
