### PR TITLE
LPS-44471

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1670,7 +1670,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		Company company = companyPersistence.findByPrimaryKey(
 			user.getCompanyId());
 
-		if (company.isStrangersVerify() && (serviceContext.getPlid() > 0)) {
+		if (company.isStrangersVerify()) {
 			sendEmailAddressVerification(
 				user, user.getEmailAddress(), serviceContext);
 		}
@@ -3392,12 +3392,19 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			serviceContext.getPortalURL() + serviceContext.getPathMain() +
 				"/portal/verify_email_address?ticketKey=" + ticket.getKey();
 
-		Layout layout = layoutLocalService.getLayout(serviceContext.getPlid());
+		long plid = serviceContext.getPlid();
 
-		Group group = layout.getGroup();
+		if (plid > 0) {
+			Layout layout = layoutLocalService.fetchLayout(plid);
 
-		if (!layout.isPrivateLayout() && !group.isUser()) {
-			verifyEmailAddressURL += "&p_l_id=" + serviceContext.getPlid();
+			if (layout != null) {
+				Group group = layout.getGroup();
+
+				if (!layout.isPrivateLayout() && !group.isUser()) {
+					verifyEmailAddressURL += "&p_l_id=" +
+						serviceContext.getPlid();
+				}
+			}
 		}
 
 		String fromName = PrefsPropsUtil.getString(


### PR DESCRIPTION
Hi Jorge,

when I use http://localhost:8080/c/portal/verify_email_address?ticketKey=... it works without plid and 
right now there is no exception in logs. 

There is another problem though, related to https://issues.liferay.com/browse/LPS-44557. This method needs to construct portal url and the only way is to get it from SessionContext or get HttpServletRequest from somewhere to call `PortalUtil.getPortalURL(httpServletRequest)`.

Without it there is a wrong url: `nullnull/portal/verify_email_address?ticketKey=09c9c62b-f79b-4dcd-b4cb-847487e177f1`, see the email below:

```
Date: Tue, 25 Feb 2014 11:10:44 +0000 (GMT)
From: Test Test <test@liferay.com>
To: fn ln <user3@liferay.com>
Message-ID: <user.10518.1393326644033.sCBK2bBd@events.liferay.com>
Subject: http://localhost:8080: Email Address Verification
MIME-Version: 1.0
Content-Type: text/html;charset="UTF-8"
Content-Transfer-Encoding: 7bit
X-Auto-Response-Suppress: AutoReply, DR, NDR, NRN, OOF, RN
X-Peer: 127.0.0.1

Dear fn ln,<br /><br />

Please verify your email address for http://localhost:8080 at nullnull/portal/verify_email_address?ticketKey=09c9c62b-f79b-4dcd-b4cb-847487e177f1.<br /><br />

Your verification code is 09c9c62b-f79b-4dcd-b4cb-847487e177f1

Sincerely,<br />
Test Test<br />
test@liferay.com<br />
http://localhost:8080<br />
```
