### PR TITLE
LPS-45704 Impersonated user can't get back to previous page after go to ...

### DIFF
--- a/portal-web/docroot/html/portlet/dockbar/view_user_account.jspf
+++ b/portal-web/docroot/html/portlet/dockbar/view_user_account.jspf
@@ -142,7 +142,7 @@
 				myAccountURL = HttpUtil.setParameter(myAccountURL, "controlPanelCategory", PortletCategoryKeys.MY);
 				%>
 
-				<aui:nav-item href="<%= myAccountURL %>" iconCssClass="icon-user" label="my-account" title="my-account" useDialog="<%= !themeDisplay.isImpersonated() && PropsValues.DOCKBAR_ADMINISTRATIVE_LINKS_SHOW_IN_POP_UP %>" />
+				<aui:nav-item href="<%= myAccountURL %>" iconCssClass="icon-user" label="my-account" title="my-account" useDialog="<%= PropsValues.DOCKBAR_ADMINISTRATIVE_LINKS_SHOW_IN_POP_UP %>" />
 			</c:if>
 
 			<c:if test="<%= themeDisplay.isShowSignOutIcon() %>">


### PR DESCRIPTION
..."My Account"

Hi Jorge,

I am sending you the pull request because of the discussion here:
https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/2409673.

I found the issue only occured when dockbar.administrative.links.show.in.pop.up=true. When the property was set "dockbar.administrative.links.show.in.pop.up=false", the issue won't be occured and the reason is as the followings.

in portal_normal.vm, please refer to the below code:
# if (($control_panel_category != "my") || !$getterUtil.getBoolean($propsUtil.get("dockbar.administrative.links.show.in.pop.up")))

```
 #dockbar()
```
# 

That  is to say, when set the property "dockbar.administrative.links.show.in.pop.up=false", the admin can get back to previous page by using dockbar portlet.

So the issue was caused by the code "!themeDisplay.isImpersonated()". We control the admin as impersonated user can't view "My Account" in popup dialog. In the meantime, the dockbar won't be  displayed after the admin go to "My Account" so that tthe admin can't get back to previous page.

In ee-6.1.x, we don't use the code "!themeDisplay.isImpersonated()" as judging whether display "My  account" in popup dialog. So the fix refers to the 6.1 behavior. 

Could you please help check if my fix is corrrect?

Thanks,
Hai
