### PR TITLE
[TECHNICAL SUPPORT] LPS-47095 User's private pages coming from a UserGroup have wrong URLs

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/VirtualLayout.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/VirtualLayout.java
@@ -161,12 +161,11 @@ public class VirtualLayout extends LayoutWrapper {
 
 			StringBundler sb = new StringBundler(5);
 
-			int pos = -1;
+			int pos = layoutURL.indexOf(
+				PropsValues.LAYOUT_FRIENDLY_URL_PRIVATE_GROUP_SERVLET_MAPPING);
 
-			if (_targetGroup.isUser() && isPrivateLayout()) {
-				pos = layoutURL.indexOf(
-					PropsValues.
-						LAYOUT_FRIENDLY_URL_PRIVATE_GROUP_SERVLET_MAPPING);
+			if (_sourceLayout.isPrivateLayout() && _targetGroup.isUser() &&
+				(pos > 0)) {
 
 				sb.append(layoutURL.substring(0, pos));
 				sb.append(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-47095

Hey Jorge,

Let us know if there would be any cases which we did not consider. I've added my SF in order to avoid StringOutOfBoundsException that is technically possible.

There is an MB Thread about this issue where Ray replied to Norbert.

Thanks,
Tibor

/cc @NorbertKocsis
