### PR TITLE
[TECHNICAL-SUPPORT | June 17] LPS-47371 Calling getContact() on a User object in an IndexerPostProcessor postProcessDocument method throws NoSuchContactException

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -830,7 +830,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		userPersistence.update(user, serviceContext);
 
-		// Resources
+		// Contact
 
 		String creatorUserName = StringPool.BLANK;
 
@@ -847,12 +847,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			creatorUserName = creatorUser.getFullName();
 		}
-
-		resourceLocalService.addResources(
-			companyId, 0, creatorUserId, User.class.getName(), user.getUserId(),
-			false, false, false);
-
-		// Contact
 
 		Date birthday = getBirthday(birthdayMonth, birthdayDay, birthdayYear);
 
@@ -885,6 +879,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			user.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
 			User.class.getName(), user.getUserId(), null, null, 0,
 			StringPool.SLASH + screenName, false, true, null);
+
+		// Resources
+
+		resourceLocalService.addResources(
+			companyId, 0, creatorUserId, User.class.getName(), user.getUserId(),
+			false, false, false);
 
 		// Groups
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-47371

Hi Jorge,

Originally, Sampsa reported this LPS, but now it is related to a customer issue as well. After checking the logic of ULSI#addUserWithWorkflow, I've found no cons not to change the order the way I did.

FYI, we do it similarly in the Organization LSI#addOrganization method.

Regards,
Tibor
