### PR TITLE
LPS-48579 Register the settings once the portlet has been loaded

### DIFF
--- a/portal-impl/src/com/liferay/portal/settings/SettingsRegister.java
+++ b/portal-impl/src/com/liferay/portal/settings/SettingsRegister.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings;
+
+import com.liferay.portal.kernel.settings.FallbackKeys;
+import com.liferay.portal.kernel.settings.SettingsFactory;
+import com.liferay.portal.kernel.settings.SettingsFactoryUtil;
+
+import java.util.List;
+
+/**
+ * @author Roberto Díaz
+ */
+public class SettingsRegister implements Runnable {
+
+	public SettingsRegister(
+		FallbackKeys fallbackKeys, String[] multiValuedKeys, String portletId) {
+
+		_fallbackKeys = fallbackKeys;
+		_multiValuedKeys = multiValuedKeys;
+		_portletId = portletId;
+	}
+
+	@Override
+	public void run() {
+		SettingsFactory settingsFactory =
+			SettingsFactoryUtil.getSettingsFactory();
+
+		List<String> multiValuedKeys = settingsFactory.getMultiValuedKeys(
+			_portletId);
+
+		if (multiValuedKeys == null) {
+			settingsFactory.registerSettingsMetadata(
+				_portletId, _fallbackKeys, _multiValuedKeys);
+		}
+	}
+
+	private FallbackKeys _fallbackKeys;
+	private String[] _multiValuedKeys = {};
+	private String _portletId;
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/DLPortletInstanceSettings.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/DLPortletInstanceSettings.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.settings.TypedSettings;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.settings.SettingsRegister;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.util.DLUtil;
@@ -46,6 +47,11 @@ public class DLPortletInstanceSettings {
 	public static DLPortletInstanceSettings getInstance(
 			Layout layout, String portletId)
 		throws PortalException {
+
+		SettingsRegister settingsRegister = new SettingsRegister(
+			_getFallbackKeys(), _MULTI_VALUED_KEYS, portletId);
+
+		settingsRegister.run();
 
 		Settings settings = SettingsFactoryUtil.getPortletInstanceSettings(
 			layout, portletId);


### PR DESCRIPTION
hi @JorgeFerrer, 

I've found that we were not registering settings for instanciable portlets

This is a functional solution, but I would like to have some feedback from you, and i have apply it only for DL portlets (it should be applied to all the XXPortletInstanceSettings classes)

Thanks!!
