### PR TITLE
[TECH-SUPPORT] LPS-53584 Unable to delete portal instance when ldap.password.policy.enabled=true

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1336,7 +1336,10 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		PasswordPolicy defaultPasswordPolicy =
 			passwordPolicyLocalService.getDefaultPasswordPolicy(companyId);
 
-		passwordPolicyLocalService.deletePasswordPolicy(defaultPasswordPolicy);
+		if (defaultPasswordPolicy != null) {
+			passwordPolicyLocalService.deletePasswordPolicy(
+				defaultPasswordPolicy);
+		}
 
 		// Portal preferences
 

--- a/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
+++ b/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
@@ -284,7 +284,9 @@ public class SystemEventAdvice
 
 		ClassedModel classedModel = (ClassedModel)arguments[0];
 
-		if (!(classedModel.getPrimaryKeyObj() instanceof Long)) {
+		if ((classedModel == null) ||
+			!(classedModel.getPrimaryKeyObj() instanceof Long)) {
+
 			if (_log.isDebugEnabled() && (phase == _PHASE_BEFORE)) {
 				_log.debug(
 					"The first parameter of " + methodInvocation +

--- a/portal-impl/test/integration/com/liferay/portal/service/CompanyLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/CompanyLocalServiceTest.java
@@ -32,6 +32,8 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Account;
@@ -65,6 +67,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import javax.portlet.PortletPreferences;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -425,6 +429,23 @@ public class CompanyLocalServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company);
 
 		VirtualHostLocalServiceUtil.getVirtualHost(company.getWebId());
+	}
+
+	@Test
+	public void testDeleteCompanyWithLDAPPasswordPolicyEnabled()
+		throws Exception {
+
+		Company company = addCompany();
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			company.getCompanyId(), true);
+
+		portletPreferences.setValue(
+			PropsKeys.LDAP_PASSWORD_POLICY_ENABLED, "true");
+
+		portletPreferences.store();
+
+		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
 	@Test(expected = RequiredCompanyException.class)


### PR DESCRIPTION
Hi Jorge,

In the current "Liferay Comp. Hier." I didn't find anyone underneath "Portal Configuration", thus I sent this to you. If you don't have time, please forward to the responsible engineer.

Thanks,
László