### PR TITLE
LPS-53910

### DIFF
--- a/portal-impl/src/com/liferay/portlet/login/action/ForgotPasswordAction.java
+++ b/portal-impl/src/com/liferay/portlet/login/action/ForgotPasswordAction.java
@@ -225,10 +225,7 @@ public class ForgotPasswordAction extends PortletAction {
 			throw new UserActiveException();
 		}
 
-		if (user.isLockout()) {
-			throw new UserLockoutException.PasswordPolicyLockout(
-				user, user.getPasswordPolicy());
-		}
+		UserLocalServiceUtil.checkLockout(user);
 
 		return user;
 	}


### PR DESCRIPTION
Hi Jorge, 
it is not possible to recover the password if the user doesn't know that he has to try a new login after the lockout time. This is very confuse for users. Could you take a look to the fix and resend to Brian? Thx.