### PR TITLE
LPS-60407

### DIFF
--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ManageLayoutControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ManageLayoutControlMenuEntry.java
@@ -50,7 +50,7 @@ public class ManageLayoutControlMenuEntry
 
 	@Override
 	public String getIconCssClass(HttpServletRequest request) {
-		return "icon-cog";
+		return "cog";
 	}
 
 	@Override

--- a/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ToggleControlsControlMenuEntry.java
+++ b/modules/apps/control-menu/control-menu-web/src/main/java/com/liferay/control/menu/web/ToggleControlsControlMenuEntry.java
@@ -59,13 +59,13 @@ public class ToggleControlsControlMenuEntry
 				"visible"));
 
 		if (toggleControls.equals("visible")) {
-			stateCss = "icon-eye-open";
+			stateCss = "view";
 		}
 		else {
-			stateCss = "icon-eye-close";
+			stateCss = "hidden";
 		}
 
-		return "controls-state-icon " + stateCss;
+		return stateCss;
 	}
 
 	@Override

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/add_application.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/add_application.jsp
@@ -87,11 +87,7 @@ refererURL.setParameter("updateLayout", "true");
 							%>
 
 							<aui:nav-item cssClass="lfr-content-item" href="">
-								<span <%= AUIUtil.buildData(data) %> class="<%= cssClass %>">
-									<i class="<%= portletInstanceable ? "icon-th-large" : "icon-stop" %>"></i>
-
-									<liferay-ui:message key="<%= PortalUtil.getPortletTitle(portlet, application, locale) %>" />
-								</span>
+								<aui:icon cssClass="<%= cssClass %>" data="<%= data %>" image='<%= portletInstanceable ? "grid" : "live" %>' label="<%= PortalUtil.getPortletTitle(portlet, application, locale) %>" markupView="lexicon" />
 
 								<%
 								data.remove("draggable");
@@ -148,10 +144,10 @@ refererURL.setParameter("updateLayout", "true");
 		<c:if test="<%= layout.isTypePortlet() %>">
 			<ul class="lfr-add-apps-legend list-unstyled">
 				<li>
-					<aui:icon image="stop" label="can-be-added-once" />
+					<aui:icon image="live" label="can-be-added-once" markupView="lexicon" />
 				</li>
 				<li>
-					<aui:icon image="th-large" label="can-be-added-several-times" />
+					<aui:icon image="grid" label="can-be-added-several-times" markupView="lexicon" />
 				</li>
 			</ul>
 

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/add_panel.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/add_panel.jsp
@@ -38,7 +38,7 @@
 
 			<c:if test="<%= !group.isControlPanel() && (hasLayoutAddPermission || hasLayoutUpdatePermission || (layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && hasLayoutCustomizePermission)) %>">
 				<div class="add-content-menu" id="<portlet:namespace />addPanelContainer">
-					<aui:button cssClass="close" name="closePanelAdd" value="&times;" />
+					<aui:icon cssClass="close" id="closePanelAdd" image="times" markupView="lexicon" url="javascript:;" />
 
 					<%
 					String[] tabs1Names = new String[0];
@@ -119,7 +119,7 @@
 
 					<span class="added-message hide" id="<portlet:namespace />addedMessage">
 						<span class="alert-success message">
-							<liferay-ui:icon iconCssClass="icon-ok-sign" /> <span id="<portlet:namespace />portletName"></span> <liferay-ui:message key="added" />
+							<aui:icon image="check" markupView="lexicon" /> <span id="<portlet:namespace />portletName"></span> <liferay-ui:message key="added" />
 
 							<a class="content-link" href="javascript:;" id="<portlet:namespace />contentLink"><liferay-ui:message key="skip-to-content" /></a>
 						</span>

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/entries/add_content.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/entries/add_content.jsp
@@ -29,13 +29,12 @@ data.put("panelURL", addURL);
 %>
 
 <li>
-	<liferay-ui:icon
+	<aui:icon
+		cssClass="control-menu-icon"
 		data="<%= data %>"
-		iconCssClass="icon-plus icon-monospaced"
 		id="addPanel"
-		label="<%= false %>"
-		linkCssClass="control-menu-icon"
-		message="add"
+		image="plus"
+		markupView="lexicon"
 		url="javascript:;"
 	/>
 </li>

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/entries/information_messages.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/entries/information_messages.jsp
@@ -33,17 +33,19 @@ data.put("panelURL", addURL);
 %>
 
 <li>
-	<liferay-ui:icon
-		iconCssClass="icon-info icon-monospaced"
+	<aui:icon
+		cssClass="control-menu-icon"
+		data="<%= data %>"
 		id="infoButton"
-		linkCssClass="control-menu-icon"
+		image="information-live"
+		markupView="lexicon"
 		url="javascript:;"
 	/>
 
 	<liferay-util:buffer var="infoContainer">
 		<c:if test="<%= informationMessagesControlMenuEntry.isModifiedLayout(themeDisplay) %>">
 			<div class="modified-layout">
-				<i class="icon-info-sign"></i>
+				<aui:icon image="information-live" markupView="lexicon" />
 
 				<span class="message-info">
 					<liferay-ui:message key="this-page-has-been-changed-since-the-last-update-from-the-site-template-excerpt" />
@@ -68,7 +70,7 @@ data.put("panelURL", addURL);
 
 		<c:if test="<%= informationMessagesControlMenuEntry.isLinkedLayout(themeDisplay) %>">
 			<div class="linked-layout">
-				<i class="icon-info-sign"></i>
+				<aui:icon image="information-live" markupView="lexicon" />
 
 				<span class="message-info">
 
@@ -93,7 +95,7 @@ data.put("panelURL", addURL);
 
 		<c:if test="<%= informationMessagesControlMenuEntry.isCustomizableLayout(themeDisplay) %>">
 			<div class="customizable-layout">
-				<i class="icon-info-sign"></i>
+				<aui:icon image="information-live" markupView="lexicon" />
 
 				<span class="message-info">
 					<c:choose>

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/entries/preview.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/entries/preview.jsp
@@ -27,13 +27,12 @@ data.put("panelURL", previewContentURL);
 %>
 
 <li>
-	<liferay-ui:icon
+	<aui:icon
+		cssClass="control-menu-icon"
 		data="<%= data %>"
-		iconCssClass="icon-desktop icon-monospaced"
 		id="previewPanel"
-		label="<%= false %>"
-		linkCssClass="control-menu-icon"
-		message="preview"
+		image="simulation-menu-closed"
+		markupView="lexicon"
 		url="javascript:;"
 	/>
 </li>

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/view.jsp
@@ -64,13 +64,11 @@ if (layout != null) {
 					%>
 
 							<li>
-								<liferay-ui:icon
-									iconCssClass='<%= controlMenuEntry.getIconCssClass(request) + " icon-monospaced" %>'
-									label="<%= false %>"
-									linkCssClass='<%= "control-menu-icon " + controlMenuEntry.getLinkCssClass(request) %>'
-									message="<%= controlMenuEntry.getLabel(locale) %>"
+								<aui:icon
+									cssClass='<%= "control-menu-icon " + controlMenuEntry.getLinkCssClass(request) %>'
+									image="<%= controlMenuEntry.getIconCssClass(request) %>"
+									markupView="lexicon"
 									url="<%= controlMenuEntry.getURL(request) %>"
-									useDialog="<%= controlMenuEntry.isUseDialog() %>"
 								/>
 							</li>
 

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/view_category.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/view_category.jsp
@@ -145,11 +145,7 @@ if (!categories.isEmpty() || !portlets.isEmpty()) {
 							%>
 
 							<aui:nav-item cssClass="lfr-content-item" href="">
-								<span <%= AUIUtil.buildData(data) %> class="<%= cssClass %>">
-									<i class="<%= portletInstanceable ? "icon-th-large" : "icon-stop" %>"></i>
-
-									<liferay-ui:message key="<%= PortalUtil.getPortletTitle(portlet, application, locale) %>" />
-								</span>
+								<aui:icon cssClass="<%= cssClass %>" data="<%= data %>" image='<%= portletInstanceable ? "grid" : "live" %>' label="<%= PortalUtil.getPortletTitle(portlet, application, locale) %>" markupView="lexicon" />
 
 								<%
 								data.remove("draggable");
@@ -191,7 +187,7 @@ if (!categories.isEmpty() || !portlets.isEmpty()) {
 
 								<aui:nav-item cssClass="lfr-archived-setup lfr-content-item" href="">
 									<span <%= AUIUtil.buildData(portletItemData) %> class="<%= cssClass %>">
-										<i class="<%= portletInstanceable ? "icon-th-large" : "icon-stop" %>"></i>
+										<aui:icon cssClass="<%= cssClass %>" data="<%= data %>" image='<%= portletInstanceable ? "grid" : "live" %>' label="<%= PortalUtil.getPortletTitle(portlet, application, locale) %>" markupView="lexicon" />
 
 										<liferay-ui:message key="<%= HtmlUtil.escape(portletItem.getName()) %>" />
 									</span>

--- a/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/control_menu/_add_panel.scss
+++ b/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/control_menu/_add_panel.scss
@@ -17,10 +17,10 @@
 		color: #869CAD;
 	}
 
-	button.close {
+	a.close {
 		color: #FFF;
 		opacity: 1;
-		padding: 2px 8px;
+		padding: 0 8px;
 
 		&:hover {
 			background: transparent;

--- a/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/control_menu/_control_menu.scss
+++ b/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/control_menu/_control_menu.scss
@@ -27,7 +27,7 @@
 		}
 
 		> .active {
-			.control-menu-icon .icon-monospaced {
+			.control-menu-icon .lexicon-icon {
 				background-color: $control-menu-level-2-nav-item-active-bg;
 				border-radius: $control-menu-level-2-nav-item-active-border-radius;
 				color: $control-menu-level-2-nav-item-active-color;
@@ -92,9 +92,8 @@
 		text-decoration: none;
 	}
 
-	&.icon-monospaced,
-	.icon-monospaced {
-		font-size: $control-menu-icon-font-size;
+	.lexicon-icon {
+		margin: $control-menu-icon-spacing;
 	}
 }
 

--- a/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/control_menu/_variables.scss
+++ b/modules/frontend/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/control_menu/_variables.scss
@@ -4,7 +4,7 @@ $editLayoutPanelWidth: 330px;
 
 $control-menu-css-transition: all 0.5s ease !default;
 
-$control-menu-icon-font-size: 1.18em !default;
+$control-menu-icon-spacing: 8px !default;
 
 $control-menu-level-1-bg: rgba(31, 40, 46, 0.95) !default;
 $control-menu-level-1-border: rgb(31, 40, 46) !default;


### PR DESCRIPTION
/cc @ealonso

Hey guys,
Sorry for the delay on this one, there were some icons that I had missed the first time around.
I wasn't able to get things 100% of the way there, but I think I covered most of them.

The two things I wasn't able to do, and if you're able to help or have ideas, that'd be awesome, but it's:
1. Since we're now using the `aui:icon` taglib, there is no `useDialog` attribute, and I'm not sure if we're using it in here anymore.
2. Inside of the Add Content area, the `aui:nav-item` taglib is taking an `iconCssClass` attribute, but I don't know of any way to cascase it down. Maybe in this case we remove it, and manually add the icon?

If you guys have any questions, or there are any issues you guys see, please let me know. I'll try to send the Product Menu one along as well, but I'll need to double check and make sure I didn't miss too much.

Thanks guys,