### PR TITLE
LPS-61301

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/CreateAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/CreateAccountMVCActionCommand.java
@@ -249,8 +249,8 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 		}
 		catch (Exception e) {
 			if (e instanceof
-						UserEmailAddressException.MustNotBeDuplicate ||
-					 e instanceof UserScreenNameException.MustNotBeDuplicate) {
+					UserEmailAddressException.MustNotBeDuplicate ||
+				e instanceof UserScreenNameException.MustNotBeDuplicate) {
 
 				String emailAddress = ParamUtil.getString(
 					actionRequest, "emailAddress");
@@ -269,32 +269,32 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 				}
 			}
 			else if (e instanceof AddressCityException ||
-				e instanceof AddressStreetException ||
-				e instanceof AddressZipException ||
-				e instanceof CaptchaConfigurationException ||
-				e instanceof CaptchaMaxChallengesException ||
-				e instanceof CaptchaTextException ||
-				e instanceof CompanyMaxUsersException ||
-				e instanceof ContactBirthdayException ||
-				e instanceof ContactNameException ||
-				e instanceof DuplicateOpenIdException ||
-				e instanceof EmailAddressException ||
-				e instanceof GroupFriendlyURLException ||
-				e instanceof NoSuchCountryException ||
-				e instanceof NoSuchListTypeException ||
-				e instanceof NoSuchOrganizationException ||
-				e instanceof NoSuchRegionException ||
-				e instanceof OrganizationParentException ||
-				e instanceof PhoneNumberException ||
-				e instanceof RequiredFieldException ||
-				e instanceof RequiredUserException ||
-				e instanceof TermsOfUseException ||
-				e instanceof UserEmailAddressException ||
-				e instanceof UserIdException ||
-				e instanceof UserPasswordException ||
-				e instanceof UserScreenNameException ||
-				e instanceof UserSmsException ||
-				e instanceof WebsiteURLException) {
+					 e instanceof AddressStreetException ||
+					 e instanceof AddressZipException ||
+					 e instanceof CaptchaConfigurationException ||
+					 e instanceof CaptchaMaxChallengesException ||
+					 e instanceof CaptchaTextException ||
+					 e instanceof CompanyMaxUsersException ||
+					 e instanceof ContactBirthdayException ||
+					 e instanceof ContactNameException ||
+					 e instanceof DuplicateOpenIdException ||
+					 e instanceof EmailAddressException ||
+					 e instanceof GroupFriendlyURLException ||
+					 e instanceof NoSuchCountryException ||
+					 e instanceof NoSuchListTypeException ||
+					 e instanceof NoSuchOrganizationException ||
+					 e instanceof NoSuchRegionException ||
+					 e instanceof OrganizationParentException ||
+					 e instanceof PhoneNumberException ||
+					 e instanceof RequiredFieldException ||
+					 e instanceof RequiredUserException ||
+					 e instanceof TermsOfUseException ||
+					 e instanceof UserEmailAddressException ||
+					 e instanceof UserIdException ||
+					 e instanceof UserPasswordException ||
+					 e instanceof UserScreenNameException ||
+					 e instanceof UserSmsException ||
+					 e instanceof WebsiteURLException) {
 
 				SessionErrors.add(actionRequest, e.getClass(), e);
 			}

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/CreateAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/CreateAccountMVCActionCommand.java
@@ -248,7 +248,27 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 			}
 		}
 		catch (Exception e) {
-			if (e instanceof AddressCityException ||
+			if (e instanceof
+						UserEmailAddressException.MustNotBeDuplicate ||
+					 e instanceof UserScreenNameException.MustNotBeDuplicate) {
+
+				String emailAddress = ParamUtil.getString(
+					actionRequest, "emailAddress");
+
+				User user = _userLocalService.fetchUserByEmailAddress(
+					themeDisplay.getCompanyId(), emailAddress);
+
+				if ((user == null) ||
+					(user.getStatus() != WorkflowConstants.STATUS_INCOMPLETE)) {
+
+					SessionErrors.add(actionRequest, e.getClass(), e);
+				}
+				else {
+					actionResponse.setRenderParameter(
+						"mvcPath", "/update_account.jsp");
+				}
+			}
+			else if (e instanceof AddressCityException ||
 				e instanceof AddressStreetException ||
 				e instanceof AddressZipException ||
 				e instanceof CaptchaConfigurationException ||
@@ -277,26 +297,6 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 				e instanceof WebsiteURLException) {
 
 				SessionErrors.add(actionRequest, e.getClass(), e);
-			}
-			else if (e instanceof
-						UserEmailAddressException.MustNotBeDuplicate ||
-					 e instanceof UserScreenNameException.MustNotBeDuplicate) {
-
-				String emailAddress = ParamUtil.getString(
-					actionRequest, "emailAddress");
-
-				User user = _userLocalService.fetchUserByEmailAddress(
-					themeDisplay.getCompanyId(), emailAddress);
-
-				if ((user == null) ||
-					(user.getStatus() != WorkflowConstants.STATUS_INCOMPLETE)) {
-
-					SessionErrors.add(actionRequest, e.getClass(), e);
-				}
-				else {
-					actionResponse.setRenderParameter(
-						"mvcPath", "update_account.jsp");
-				}
 			}
 			else {
 				throw e;

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/CreateAnonymousAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/CreateAnonymousAccountMVCActionCommand.java
@@ -223,16 +223,6 @@ public class CreateAnonymousAccountMVCActionCommand
 				JSONPortletResponseUtil.writeJSON(
 					actionRequest, actionResponse, jsonObject);
 			}
-			else if (e instanceof CaptchaConfigurationException ||
-					 e instanceof CaptchaTextException ||
-					 e instanceof CompanyMaxUsersException ||
-					 e instanceof ContactNameException ||
-					 e instanceof EmailAddressException ||
-					 e instanceof GroupFriendlyURLException ||
-					 e instanceof UserEmailAddressException) {
-
-				SessionErrors.add(actionRequest, e.getClass(), e);
-			}
 			else if (e instanceof
 						UserEmailAddressException.MustNotBeDuplicate) {
 
@@ -246,6 +236,16 @@ public class CreateAnonymousAccountMVCActionCommand
 					sendRedirect(
 						actionRequest, actionResponse, portletURL.toString());
 				}
+			}
+			else if (e instanceof CaptchaConfigurationException ||
+					 e instanceof CaptchaTextException ||
+					 e instanceof CompanyMaxUsersException ||
+					 e instanceof ContactNameException ||
+					 e instanceof EmailAddressException ||
+					 e instanceof GroupFriendlyURLException ||
+					 e instanceof UserEmailAddressException) {
+
+				SessionErrors.add(actionRequest, e.getClass(), e);
 			}
 			else {
 				_log.error("Unable to create anonymous account", e);


### PR DESCRIPTION
Hi Jorge,

sending this PR to you because it's related to the new Exception naming.

The problem is that we catch more general exception class before the specific one, for example UserEmailAddressException is checked before UserEmailAddressException.MustNotBeDuplicate. Any code that is bound to the MustNotBeDuplicate is never invoked because MustNotBeDuplicate also extends UserEmailAddressException.

I believe this can be also on other places in portal. Can you please look at it / give other teams a heads up?

Thank you.