### PR TITLE
LPS-64395 System Settings configurations are not sorted, making it difficult for a user to find the right configuration

### DIFF
--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelIterator.java
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelIterator.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -44,7 +45,22 @@ public class ConfigurationModelIterator {
 	}
 
 	public List<ConfigurationModel> getResults(int start, int end) {
-		return ListUtil.subList(_configurationModels, start, end);
+		return getResults(start, end, null);
+	}
+
+	public List<ConfigurationModel> getResults(
+		int start, int end, Comparator<ConfigurationModel> comparator) {
+
+		if (comparator == null) {
+			return ListUtil.subList(_configurationModels, start, end);
+		}
+
+		List<ConfigurationModel> configurationModels = new ArrayList<>(
+			_configurationModels);
+
+		configurationModels = ListUtil.sort(configurationModels, comparator);
+
+		return ListUtil.subList(configurationModels, start, end);
 	}
 
 	public int getTotal() {

--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelNameComparator.java
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelNameComparator.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.web.util;
+
+import com.liferay.configuration.admin.web.model.ConfigurationModel;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+
+import java.util.Comparator;
+import java.util.ResourceBundle;
+
+/**
+ * @author Andrew Betts
+ */
+public class ConfigurationModelNameComparator
+	implements Comparator<ConfigurationModel> {
+
+	public ConfigurationModelNameComparator(
+		String languageId,
+		ResourceBundleLoaderProvider resourceBundleLoaderProvider) {
+
+		_languageId = languageId;
+		_resourceBundleLoaderProvider = resourceBundleLoaderProvider;
+	}
+
+	@Override
+	public int compare(
+		ConfigurationModel configurationModel1,
+		ConfigurationModel configurationModel2) {
+
+		String name1 = getConfigurationModelName(configurationModel1);
+		String name2 = getConfigurationModelName(configurationModel2);
+
+		return name1.compareTo(name2);
+	}
+
+	private String getConfigurationModelName(
+		ConfigurationModel configurationModel) {
+
+		String bundleSymbolicName = configurationModel.getBundleSymbolicName();
+
+		ResourceBundleLoader resourceBundleLoader =
+			_resourceBundleLoaderProvider.getResourceBundleLoader(
+				bundleSymbolicName);
+
+		ResourceBundle componentResourceBundle =
+			resourceBundleLoader.loadResourceBundle(_languageId);
+
+		String name = configurationModel.getName();
+
+		if (componentResourceBundle == null) {
+			return name;
+		}
+
+		return LanguageUtil.get(componentResourceBundle, name);
+	}
+
+	private final String _languageId;
+	private final ResourceBundleLoaderProvider _resourceBundleLoaderProvider;
+
+}

--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -29,6 +29,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.configuration.admin.web.constants.ConfigurationAdminWebKeys" %><%@
 page import="com.liferay.configuration.admin.web.model.ConfigurationModel" %><%@
 page import="com.liferay.configuration.admin.web.util.ConfigurationModelIterator" %><%@
+page import="com.liferay.configuration.admin.web.util.ConfigurationModelNameComparator" %><%@
 page import="com.liferay.configuration.admin.web.util.ResourceBundleLoaderProvider" %><%@
 page import="com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@

--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,6 +36,10 @@ if (Validator.isNotNull(keywords)) {
 
 	renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 }
+
+String languageId = LanguageUtil.getLanguageId(request);
+
+ConfigurationModelNameComparator configurationModelNameComparator = new ConfigurationModelNameComparator(languageId, resourceBundleLoaderProvider);
 %>
 
 <aui:nav-bar cssClass="collapse-basic-search" markupView="lexicon">
@@ -82,7 +86,7 @@ if (Validator.isNotNull(keywords)) {
 		total="<%= configurationModelIterator.getTotal() %>"
 	>
 		<liferay-ui:search-container-results
-			results="<%= configurationModelIterator.getResults(searchContainer.getStart(), searchContainer.getEnd()) %>"
+			results="<%= configurationModelIterator.getResults(searchContainer.getStart(), searchContainer.getEnd(), configurationModelNameComparator) %>"
 		/>
 
 		<liferay-ui:search-container-row
@@ -108,7 +112,7 @@ if (Validator.isNotNull(keywords)) {
 				<%
 				ResourceBundleLoader resourceBundleLoader = resourceBundleLoaderProvider.getResourceBundleLoader(configurationModel.getBundleSymbolicName());
 
-				ResourceBundle componentResourceBundle = resourceBundleLoader.loadResourceBundle(LanguageUtil.getLanguageId(request));
+				ResourceBundle componentResourceBundle = resourceBundleLoader.loadResourceBundle(languageId);
 
 				String configurationModelName = (componentResourceBundle != null) ? LanguageUtil.get(componentResourceBundle, configurationModel.getName()) : configurationModel.getName();
 				%>


### PR DESCRIPTION
This is an update for [LPS-64395](https://issues.liferay.com/browse/LPS-64395).

Hey @JorgeFerrer, this is not an essential change, but it's nice to have.  Also, I'm aware that we have a ConfiguratioModelComparator [here](https://github.com/drewbrokke/liferay-portal/blob/master/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelRetrieverImpl.java#L379-L393), but in order to move the logic there we'd have to modify the `ConfigurationModelRetriever` interface to allow a locale to be passed into the `categorizeConfigurationModels`.  If we're okay doing that then I can update the fix.  Let me know what you think.

/cc @arbetts @pei-jung
