### PR TITLE
LPS-82051 When deploy a Configuration Category from a different module than configuration-admin-web , the category label will be not localized

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
@@ -15,6 +15,12 @@
 package com.liferay.configuration.admin.web.internal.display;
 
 import com.liferay.configuration.admin.category.ConfigurationCategory;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 /**
  * @author Jorge Ferrer
@@ -25,6 +31,20 @@ public class ConfigurationCategoryDisplay {
 		ConfigurationCategory configurationCategory) {
 
 		_configurationCategory = configurationCategory;
+	}
+
+	public String getCategoryLabel(Locale locale) {
+		ResourceBundleLoader resourceBundleLoader =
+			ResourceBundleLoaderUtil.
+				getResourceBundleLoaderByBundleSymbolicName(
+					_configurationCategory.getBundleSymbolicName());
+
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			locale);
+
+		return LanguageUtil.get(
+			resourceBundle,
+			"category." + _configurationCategory.getCategoryKey());
 	}
 
 	public String getCategoryIcon() {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
@@ -33,6 +33,14 @@ public class ConfigurationCategoryDisplay {
 		_configurationCategory = configurationCategory;
 	}
 
+	public String getCategoryIcon() {
+		return _configurationCategory.getCategoryIcon();
+	}
+
+	public String getCategoryKey() {
+		return _configurationCategory.getCategoryKey();
+	}
+
 	public String getCategoryLabel(Locale locale) {
 		ResourceBundleLoader resourceBundleLoader =
 			ResourceBundleLoaderUtil.
@@ -45,14 +53,6 @@ public class ConfigurationCategoryDisplay {
 		return LanguageUtil.get(
 			resourceBundle,
 			"category." + _configurationCategory.getCategoryKey());
-	}
-
-	public String getCategoryIcon() {
-		return _configurationCategory.getCategoryIcon();
-	}
-
-	public String getCategoryKey() {
-		return _configurationCategory.getCategoryKey();
 	}
 
 	public String getCategorySection() {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,4 +1,4 @@
-HtmlUtil<%--
+<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,4 +1,4 @@
-<%--
+HtmlUtil<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -41,6 +41,7 @@ page import="com.liferay.configuration.admin.web.internal.util.ResourceBundleLoa
 page import="com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition" %><%@
 page import="com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.ResourceBundleLoader" %><%@

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -65,7 +65,7 @@ List<ConfigurationCategorySectionDisplay> configurationCategorySectionDisplays =
 								/>
 
 								<span class="list-group-card-item-text">
-									<liferay-ui:message key='<%= "category." + configurationCategoryDisplay.getCategoryKey() %>' />
+									<%= HtmlUtil.escape(configurationCategoryDisplay.getCategoryLabel(locale)) %>
 								</span>
 							</a>
 						</li>


### PR DESCRIPTION
This is an update for [LPS-82051](https://issues.liferay.com/browse/LPS-82051).<br><br>Hey Jorge, I associated this change with a ticket number and made a couple SF changes.  I thought about also providing a way to derive the bundle symbolic name from the components like I did here: https://github.com/liferay/liferay-portal/blob/master/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADLanguageUtil.java#L55.  I did not make the change right now, but it is something we can consider to make the SPI easier to implement.  Thoughts?<br><br>/cc @pei-jung @marco-leo @Commando18