### PR TITLE
LPS 134949 invocation context

### DIFF
--- a/modules/apps/portal/portal-context/bnd.bnd
+++ b/modules/apps/portal/portal-context/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Context
+Bundle-SymbolicName: com.liferay.portal.context
+Bundle-Version: 6.0.1

--- a/modules/apps/portal/portal-context/build.gradle
+++ b/modules/apps/portal/portal-context/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+}

--- a/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/CompanyInvocationContextProviderImpl.java
+++ b/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/CompanyInvocationContextProviderImpl.java
@@ -33,17 +33,26 @@ public class CompanyInvocationContextProviderImpl
 
 	@Override
 	public Company getCurrent() {
-		try {
-
-			// TODO: What is the best way to handle when the current invocation
-			//  is not happening in the context of a Company?
-
-			return _userLocalService.getCompany(
-				CompanyThreadLocal.getCompanyId());
+		if (!isPresent()) {
+			return null;
 		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
+
+		return _userLocalService.fetchCompany(getCompanyId());
+	}
+
+	@Override
+	public boolean isPresent() {
+		Long companyId = getCompanyId();
+
+		if ((companyId == null) || (companyId == 0)) {
+			return false;
 		}
+
+		return true;
+	}
+
+	protected Long getCompanyId() {
+		return CompanyThreadLocal.getCompanyId();
 	}
 
 	@Reference

--- a/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/CompanyInvocationContextProviderImpl.java
+++ b/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/CompanyInvocationContextProviderImpl.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.context.internal;
+
+import com.liferay.portal.kernel.context.CompanyInvocationContextProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.CompanyThreadLocal;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Ferrer
+ */
+@Component(service = CompanyInvocationContextProvider.class)
+public class CompanyInvocationContextProviderImpl
+	implements CompanyInvocationContextProvider {
+
+	@Override
+	public Company getCurrent() {
+		try {
+
+			// TODO: What is the best way to handle when the current invocation
+			//  is not happening in the context of a Company?
+
+			return _userLocalService.getCompany(
+				CompanyThreadLocal.getCompanyId());
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _userLocalService;
+
+}

--- a/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/GroupInvocationContextProviderImpl.java
+++ b/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/GroupInvocationContextProviderImpl.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.context.internal;
+
+import com.liferay.portal.kernel.context.GroupInvocationContextProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Ferrer
+ */
+@Component(service = GroupInvocationContextProvider.class)
+public class GroupInvocationContextProviderImpl
+	implements GroupInvocationContextProvider {
+
+	@Override
+	public Group getCurrent() {
+		try {
+
+			// TODO: What is the best way to handle when the current invocation
+			//  is not happening in the context of a Group?
+
+			return _userLocalService.getGroup(GroupThreadLocal.getGroupId());
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Reference
+	private GroupLocalService _userLocalService;
+
+}

--- a/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/GroupInvocationContextProviderImpl.java
+++ b/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/GroupInvocationContextProviderImpl.java
@@ -32,19 +32,29 @@ public class GroupInvocationContextProviderImpl
 
 	@Override
 	public Group getCurrent() {
-		try {
-
-			// TODO: What is the best way to handle when the current invocation
-			//  is not happening in the context of a Group?
-
-			return _userLocalService.getGroup(GroupThreadLocal.getGroupId());
+		if (!isPresent()) {
+			return null;
 		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
+
+		return _groupLocalService.fetchGroup(getGroupId());
+	}
+
+	protected Long getGroupId() {
+		return GroupThreadLocal.getGroupId();
+	}
+
+	@Override
+	public boolean isPresent() {
+		Long groupId = getGroupId();
+
+		if ((groupId == null) || (groupId == 0)) {
+			return false;
 		}
+
+		return true;
 	}
 
 	@Reference
-	private GroupLocalService _userLocalService;
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/UserInvocationContextProviderImpl.java
+++ b/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/UserInvocationContextProviderImpl.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.context.internal;
+
+import com.liferay.portal.kernel.context.UserInvocationContextProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Ferrer
+ */
+@Component(service = UserInvocationContextProvider.class)
+public class UserInvocationContextProviderImpl
+	implements UserInvocationContextProvider {
+
+	@Override
+	public User getCurrent() {
+		try {
+			return _userLocalService.getUser(PrincipalThreadLocal.getUserId());
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/UserInvocationContextProviderImpl.java
+++ b/modules/apps/portal/portal-context/src/main/java/com/liferay/portal/context.internal/UserInvocationContextProviderImpl.java
@@ -15,8 +15,8 @@
 package com.liferay.portal.context.internal;
 
 import com.liferay.portal.kernel.context.UserInvocationContextProvider;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 
@@ -32,12 +32,26 @@ public class UserInvocationContextProviderImpl
 
 	@Override
 	public User getCurrent() {
-		try {
-			return _userLocalService.getUser(PrincipalThreadLocal.getUserId());
+		if (!isPresent()) {
+			return null;
 		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
+
+		return _userLocalService.fetchUser(getUserId());
+	}
+
+	@Override
+	public boolean isPresent() {
+		Long companyId = getUserId();
+
+		if ((companyId == null) || (companyId == 0)) {
+			return false;
 		}
+
+		return true;
+	}
+
+	protected Long getUserId() {
+		return PrincipalThreadLocal.getUserId();
 	}
 
 	@Reference

--- a/portal-kernel/src/com/liferay/portal/kernel/context/AccountInvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/AccountInvocationContextProvider.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.context;
+
+/**
+ * @author Jorge Ferrer
+ */
+public interface AccountInvocationContextProvider<Account>
+	extends InvocationContextProvider {
+
+	public Account getCurrentAccount();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/context/CompanyInvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/CompanyInvocationContextProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.context;
+
+import com.liferay.portal.kernel.model.Company;
+
+/**
+ * @author Jorge Ferrer
+ */
+public interface CompanyInvocationContextProvider
+	extends InvocationContextProvider<Company> {
+
+	public Company getCurrent();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/context/GroupInvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/GroupInvocationContextProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.context;
+
+import com.liferay.portal.kernel.model.Group;
+
+/**
+ * @author Jorge Ferrer
+ */
+public interface GroupInvocationContextProvider
+	extends InvocationContextProvider<Group> {
+
+	public Group getCurrent();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/context/InvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/InvocationContextProvider.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.context;
+
+/**
+ * @author Jorge Ferrer
+ */
+public interface InvocationContextProvider<T> {
+
+	public T getCurrent();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/context/InvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/InvocationContextProvider.java
@@ -21,4 +21,6 @@ public interface InvocationContextProvider<T> {
 
 	public T getCurrent();
 
+	public boolean isPresent();
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/context/LayoutInvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/LayoutInvocationContextProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.context;
+
+import com.liferay.portal.kernel.model.Layout;
+
+/**
+ * @author Jorge Ferrer
+ */
+public interface LayoutInvocationContextProvider
+	extends InvocationContextProvider<Layout> {
+
+	public Layout getCurrent();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/context/UserInvocationContextProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/context/UserInvocationContextProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.context;
+
+import com.liferay.portal.kernel.model.User;
+
+/**
+ * @author Jorge Ferrer
+ */
+public interface UserInvocationContextProvider
+	extends InvocationContextProvider<User> {
+
+	public User getCurrent();
+
+}


### PR DESCRIPTION
- LPS-134949 New interface to declare providers of invocation context objects
- LPS-134949 Interfaces for common invocation context objects
- LPS-134949 New module to host implementations of context providers
- LPS-134949 Initial implementations of context providers for Company, Group and user based on ThreadLocal
- LPS-134949 Introduce method isPresent() to allow checking whether the object is present in the current invocation context
